### PR TITLE
Limit input char with 500

### DIFF
--- a/discord/bot.js
+++ b/discord/bot.js
@@ -15,6 +15,7 @@ const client = new Client({
 });
 
 const token = process.env.DISCORD_BOT_TOKEN;
+const maxCharSize = 500;
 
 const model = genAI.getGenerativeModel({
   model: "gemini-1.5-pro-latest",
@@ -60,6 +61,14 @@ client.on("interactionCreate", async (interaction) => {
 
   if (commandName === "fix") {
     const userMessage = options.getString("message");
+
+    if (userMessage.length > maxCharSize) {
+      await interaction.reply(
+        `❌ Your message is too long! Please keep it under ${maxCharSize} characters.`
+      );
+      return;
+    }
+
     try {
       // Acknowledge the interaction to avoid timing out
       await interaction.deferReply();


### PR DESCRIPTION
This pull request fixes the issue of allowing input messages with more than 500 characters. The code now checks the length of the user's message and displays an error if it exceeds the limit. This ensures that the bot can handle messages within the specified character limit. Fixes #1.